### PR TITLE
Schema DDL: add support for 'date' format

### DIFF
--- a/0-common/schema-ddl/src/main/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/StringProperties.scala
+++ b/0-common/schema-ddl/src/main/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/StringProperties.scala
@@ -52,6 +52,7 @@ object StringProperties {
   case object Ipv6Format extends Format { val asString = "ipv6" }
   case object EmailFormat extends Format { val asString = "email" }
   case object DateTimeFormat extends Format { val asString = "date-time" }
+  case object DateFormat extends Format { val asString = "date" }
   case object HostNameFormat extends Format { val asString = "hostname" }
 
   /**

--- a/0-common/schema-ddl/src/main/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/json4s/StringSerializers.scala
+++ b/0-common/schema-ddl/src/main/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/json4s/StringSerializers.scala
@@ -29,6 +29,7 @@ object StringSerializers {
       case JString(format) if format == "email" => EmailFormat
       case JString(format) if format == "hostname" => HostNameFormat
       case JString(format) if format == "date-time" => DateTimeFormat
+      case JString(format) if format == "date" => DateFormat
       case JString(format) => CustomFormat(format)
       case x => throw new MappingException("Format must be string")
     },

--- a/0-common/schema-ddl/src/main/scala/com.snowplowanalytics/iglu.schemaddl/redshift/DataType.scala
+++ b/0-common/schema-ddl/src/main/scala/com.snowplowanalytics/iglu.schemaddl/redshift/DataType.scala
@@ -22,6 +22,10 @@ case object RedshiftTimestamp extends DataType {
   def toDdl = "TIMESTAMP"
 }
 
+case object RedshiftDate extends DataType {
+  def toDdl = "DATE"
+}
+
 case object RedshiftSmallInt extends DataType {
   def toDdl = "SMALLINT"
 }

--- a/0-common/schema-ddl/src/main/scala/com.snowplowanalytics/iglu.schemaddl/redshift/generators/DdlGenerator.scala
+++ b/0-common/schema-ddl/src/main/scala/com.snowplowanalytics/iglu.schemaddl/redshift/generators/DdlGenerator.scala
@@ -185,6 +185,7 @@ object DdlGenerator {
     complexEnumSuggestion,
     productSuggestion,
     timestampSuggestion,
+    dateSuggestion,
     arraySuggestion,
     integerSuggestion,
     numberSuggestion,

--- a/0-common/schema-ddl/src/main/scala/com.snowplowanalytics/iglu.schemaddl/redshift/generators/TypeSuggestions.scala
+++ b/0-common/schema-ddl/src/main/scala/com.snowplowanalytics/iglu.schemaddl/redshift/generators/TypeSuggestions.scala
@@ -54,6 +54,13 @@ object TypeSuggestions {
       case _ => None
     }
 
+  val dateSuggestion: DataTypeSuggestion = (properties, columnName) =>
+    (properties.get("type"), properties.get("format")) match {
+      case(Some(types), Some("date")) if types.contains("string") =>
+        Some(RedshiftDate)
+      case _ => None
+    }
+
   val arraySuggestion: DataTypeSuggestion = (properties, columnName) =>
     properties.get("type") match {
       case Some(types) if types.contains("array") =>

--- a/0-common/schema-ddl/src/test/scala/com/snowplowanalytics/iglu/schemaddl/redshift/generators/TypeSuggestionsSpec.scala
+++ b/0-common/schema-ddl/src/test/scala/com/snowplowanalytics/iglu/schemaddl/redshift/generators/TypeSuggestionsSpec.scala
@@ -24,6 +24,8 @@ class TypeSuggestionsSpec extends Specification { def is = s2"""
     recognize string,null maxLength == minLength as CHAR $e4
     recognize number with product type $e5
     recognize integer with product type $e6
+    recognize timestamp $e7
+    recognize full date $e8
   """
 
   def e1 = {
@@ -54,5 +56,15 @@ class TypeSuggestionsSpec extends Specification { def is = s2"""
   def e6 = {
     val props = Map("type" -> "integer,null")
     DdlGenerator.getDataType(props, 16, "somecolumn") must beEqualTo(RedshiftBigInt)
+  }
+
+  def e7 = {
+    val props = Map("type" -> "string", "format" -> "date-time")
+    DdlGenerator.getDataType(props, 16, "somecolumn") must beEqualTo(RedshiftTimestamp)
+  }
+
+  def e8 = {
+    val props = Map("type" -> "string", "format" -> "date")
+    DdlGenerator.getDataType(props, 16, "somecolumn") must beEqualTo(RedshiftDate)
   }
 }


### PR DESCRIPTION
This adds support for suggesting a Redshift `DATE` type when specifying `"format": "date"` in a JSON schema.

It's not entirely clear as to what is the best way to support a date with no time component as date was present in [JSON schema v3](https://tools.ietf.org/html/draft-zyp-json-schema-03) but removed in later versions. In v4 the spec mentions that anything with `"format": "date-time"` should meet section [5.6 of RFC3339](https://tools.ietf.org/html/rfc3339#section-5.6) but the ABNF for "date-time" suggests that both a full date and a full time are required
`date-time       = full-date "T" full-time` this differs from the ISO8601 which allows for partial dates. Thoughts @chuwy @alexanderdean?