### PR TITLE
Scala Core: Remove resolutionRepos from BuildSettings (Closes #390)

### DIFF
--- a/0-common/scala-core/project/BuildSettings.scala
+++ b/0-common/scala-core/project/BuildSettings.scala
@@ -26,8 +26,7 @@ object BuildSettings {
     scalacOptions      := Seq("-deprecation", "-encoding", "utf8", "-Yrangepos",
                               "-feature", "-unchecked",
                               "-Xlint",
-                              "-Xlog-reflective-calls"),
-    resolvers     ++= Dependencies.resolutionRepos
+                              "-Xlog-reflective-calls")
   )
 
   // Basic settings only for Iglu Core


### PR DESCRIPTION
To make the module compilable.