### PR TITLE
Switch method order in Scaladoc

### DIFF
--- a/0-common/scala-core/src/main/scala/com.snowplowanalytics.iglu/core/SelfDescribingData.scala
+++ b/0-common/scala-core/src/main/scala/com.snowplowanalytics.iglu/core/SelfDescribingData.scala
@@ -19,8 +19,8 @@ import typeclasses.{ NormalizeData, StringifyData, ToData }
   * Used to eliminate need of Option container when extracting
   * `SchemaKey` with `ExtractSchemaKey` type class
   *
-  * @param data reference to Schema
   * @param schema attached data instance itself
+  * @param data reference to Schema
   * @tparam D generic type to represent data instance type
   *           (usually it is some JSON-library's base trait)
   */


### PR DESCRIPTION
Ensures that Scaladoc matches the class definition. #394 