### PR TITLE
Use scala 2.13 in iglu core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: scala
+dist: trusty
 scala:
 - 2.11.8
 jdk:
-- openjdk8
+- oraclejdk8
 script:
 - .travis/publish_local.sh
 - cd 2-repositories/iglu-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 scala:
 - 2.11.8
 jdk:
-- oraclejdk8
+- openjdk8
 script:
 - .travis/publish_local.sh
 - cd 2-repositories/iglu-server

--- a/0-common/scala-core/iglu-core-circe/src/main/scala/com.snowplowanalytics.iglu.core.circe/instances.scala
+++ b/0-common/scala-core/iglu-core-circe/src/main/scala/com.snowplowanalytics.iglu.core.circe/instances.scala
@@ -14,7 +14,6 @@ package com.snowplowanalytics.iglu.core
 package circe
 
 import cats.{ Show, Eq }
-import cats.syntax.either._
 
 import io.circe._
 
@@ -52,7 +51,9 @@ trait instances {
       def getContent(schema: Json): Json =
         Json.fromJsonObject {
           JsonObject.fromMap {
-            schema.asObject.map(_.toMap.filterKeys(_ != "self")).getOrElse(Map.empty)
+            schema.asObject
+              .map(_.toMap.filter { case (key, _) => key != "self" })
+              .getOrElse(Map.empty)
           }
         }
     }

--- a/0-common/scala-core/iglu-core-circe/src/test/scala/com/snowplowanalytics/iglu/core/circe/AttachSchemaKeySpec.scala
+++ b/0-common/scala-core/iglu-core-circe/src/test/scala/com/snowplowanalytics/iglu/core/circe/AttachSchemaKeySpec.scala
@@ -16,9 +16,6 @@ package com.snowplowanalytics.iglu.core.circe
 import com.snowplowanalytics.iglu.core.typeclasses.NormalizeSchema
 import org.specs2.Specification
 
-// cats (for Scala 2.11)
-import cats.syntax.either._
-
 // Circe
 import io.circe._
 import io.circe.literal._

--- a/0-common/scala-core/iglu-core-circe/src/test/scala/com/snowplowanalytics/iglu/core/circe/ContainersSpec.scala
+++ b/0-common/scala-core/iglu-core-circe/src/test/scala/com/snowplowanalytics/iglu/core/circe/ContainersSpec.scala
@@ -15,8 +15,6 @@ package com.snowplowanalytics.iglu.core.circe
 // specs2
 import org.specs2.Specification
 
-import cats.syntax.either._
-
 // circe
 import io.circe._
 import io.circe.literal._

--- a/0-common/scala-core/iglu-core-circe/src/test/scala/com/snowplowanalytics/iglu/core/circe/DecordersSpec.scala
+++ b/0-common/scala-core/iglu-core-circe/src/test/scala/com/snowplowanalytics/iglu/core/circe/DecordersSpec.scala
@@ -12,9 +12,6 @@
  */
 package com.snowplowanalytics.iglu.core.circe
 
-// cats
-import cats.syntax.either._
-
 // circe
 import io.circe._
 import io.circe.literal._

--- a/0-common/scala-core/iglu-core-circe/src/test/scala/com/snowplowanalytics/iglu/core/circe/ExtractSchemaKeySpec.scala
+++ b/0-common/scala-core/iglu-core-circe/src/test/scala/com/snowplowanalytics/iglu/core/circe/ExtractSchemaKeySpec.scala
@@ -15,8 +15,6 @@ package com.snowplowanalytics.iglu.core.circe
 // specs2
 import org.specs2.Specification
 
-import cats.syntax.either._
-
 // circe
 import io.circe._
 import io.circe.literal._
@@ -111,7 +109,7 @@ class ExtractSchemaKeySpec extends Specification { def is = s2"""
         }
       """
 
-    SchemaMap.extract(json) must beLeft(ParseError.InvalidSchemaVer)
+    SchemaMap.extract(json) must beLeft[ParseError](ParseError.InvalidSchemaVer)
   }
 
   def e7 = {
@@ -125,6 +123,6 @@ class ExtractSchemaKeySpec extends Specification { def is = s2"""
         }
       """
 
-    SchemaKey.extract(json) must beLeft
+    SchemaKey.extract(json) must beLeft[ParseError]
   }
 }

--- a/0-common/scala-core/iglu-core-json4s/src/main/scala/com.snowplowanalytics.iglu.core.json4s/Json4sIgluCodecs.scala
+++ b/0-common/scala-core/iglu-core-json4s/src/main/scala/com.snowplowanalytics.iglu.core.json4s/Json4sIgluCodecs.scala
@@ -69,7 +69,7 @@ object Json4sIgluCodecs {
   object DataSerializer extends CustomSerializer[SelfDescribingData[JValue]](_ => (
     {
       case fullInstance: JObject =>
-        val schemaKey = (fullInstance \ "schema").extractOpt[String].flatMap(SchemaKey.fromUri(_).right.toOption).getOrElse {
+        val schemaKey = (fullInstance \ "schema").extractOpt[String].flatMap(SchemaKey.fromUri(_).toOption).getOrElse {
           throw new MappingException("Does not contain schema key with valid Schema URI")
         }
         val data = fullInstance \ "data" match {

--- a/0-common/scala-core/iglu-core-json4s/src/test/scala/com.snowplowanalytics.iglu.core.json4s/ExtractSchemaKeySpec.scala
+++ b/0-common/scala-core/iglu-core-json4s/src/test/scala/com.snowplowanalytics.iglu.core.json4s/ExtractSchemaKeySpec.scala
@@ -108,7 +108,7 @@ class ExtractSchemaKeySpec extends Specification { def is = s2"""
         |}
       """.stripMargin)
 
-    SchemaMap.extract(json) must beLeft(ParseError.InvalidSchema)
+    SchemaMap.extract(json) must beLeft[ParseError](ParseError.InvalidSchema)
   }
 
   def e7 = {
@@ -122,6 +122,6 @@ class ExtractSchemaKeySpec extends Specification { def is = s2"""
         |}
       """.stripMargin)
 
-    SchemaKey.extract(json) must beLeft(ParseError.InvalidSchemaVer)
+    SchemaKey.extract(json) must beLeft[ParseError](ParseError.InvalidSchemaVer)
   }
 }

--- a/0-common/scala-core/project/BuildSettings.scala
+++ b/0-common/scala-core/project/BuildSettings.scala
@@ -21,8 +21,8 @@ object BuildSettings {
   lazy val commonSettings = Seq[Setting[_]](
     organization                        := "com.snowplowanalytics",
     version                             := "0.4.0",
-    scalaVersion                        := "2.12.6",
-    crossScalaVersions                  := Seq("2.11.12", "2.12.6"),
+    scalaVersion                        := "2.13.1",
+    crossScalaVersions                  := Seq("2.12.10", "2.13.1"),
     scalacOptions                       := compilerFlags.value,
     scalacOptions in (Compile, console) --=
       Seq("-Ywarn-unused:imports", "-Xfatal-warnings")
@@ -108,15 +108,19 @@ object BuildSettings {
   // All recommended compiler flags, working on particular version of Scalac
   lazy val compilerFlags = {
     scalaVersion.map { version =>
-      if (version.startsWith("2.12."))
+      if (version.startsWith("2.13."))
         allScalacFlags.diff(Seq(
+          "-Xlint:by-name-right-associative", // not available
+          "-Xlint:unsound-match", // not available
+          "-Yno-adapted-args", // not available. Can be returned in future https://github.com/scala/bug/issues/11110
+          "-Ypartial-unification", // enabled by default
+          "-Ywarn-inaccessible", // not available. the same as -Xlint:inaccessible
+          "-Ywarn-infer-any", // not available. The same as -Xlint:infer-any
+          "-Ywarn-nullary-override", // not available. The same as -Xlint:nullary-override
+          "-Ywarn-nullary-unit", // not available. The same as -Xlint:nullary-unit
+          "-Xfuture",   // not available
           "-Ywarn-unused:imports"         // cats.syntax.either._
         ))
-      else if (version.startsWith("2.11."))
-        allScalacFlags.diff(Seq(
-          "-Xlint:constant",              // not available
-          "-Ywarn-extra-implicit"
-        )).filterNot(_.startsWith("-Ywarn-unused:"))
       else allScalacFlags
     }
   }

--- a/0-common/scala-core/project/BuildSettings.scala
+++ b/0-common/scala-core/project/BuildSettings.scala
@@ -20,7 +20,7 @@ object BuildSettings {
   // Basic settings common for Iglu project and all its subprojects
   lazy val commonSettings = Seq[Setting[_]](
     organization                        := "com.snowplowanalytics",
-    version                             := "0.4.0",
+    version                             := "0.7.0",
     scalaVersion                        := "2.13.1",
     crossScalaVersions                  := Seq("2.12.10", "2.13.1"),
     scalacOptions                       := compilerFlags.value,

--- a/0-common/scala-core/project/Dependencies.scala
+++ b/0-common/scala-core/project/Dependencies.scala
@@ -15,10 +15,10 @@ import sbt._
 object Dependencies {
   object V {
     // Scala
-    val json4s          = "3.2.11"
-    val circe           = "0.10.1"
-    val cats            = "1.4.0"
-    val specs2          = "4.3.2"
+    val json4s          = "3.6.7"
+    val circe           = "0.12.1"
+    val cats            = "2.0.0"
+    val specs2          = "4.7.1"
   }
 
   object Libraries {

--- a/0-common/scala-core/src/main/scala/com.snowplowanalytics.iglu/core/PartialSchemaKey.scala
+++ b/0-common/scala-core/src/main/scala/com.snowplowanalytics.iglu/core/PartialSchemaKey.scala
@@ -65,7 +65,7 @@ object PartialSchemaKey {
     */
   def fromUri(schemaUri: String): Either[ParseError, PartialSchemaKey] = schemaUri match {
     case schemaUriRegex(vnd, n, f, m, r, a) =>
-      SchemaVer.parse(s"$m-$r-$a").right.map(PartialSchemaKey(vnd, n, f, _))
+      SchemaVer.parse(s"$m-$r-$a").map(PartialSchemaKey(vnd, n, f, _))
     case _ => Left(ParseError.InvalidIgluUri)
   }
 }

--- a/0-common/scala-core/src/test/scala/com/snowplowanalytics/iglu/core/IgluJson4sCodecs.scala
+++ b/0-common/scala-core/src/test/scala/com/snowplowanalytics/iglu/core/IgluJson4sCodecs.scala
@@ -69,7 +69,7 @@ object IgluJson4sCodecs {
   object DataSerializer extends CustomSerializer[SelfDescribingData[JValue]](_ => (
     {
       case fullInstance: JObject =>
-        val schemaKey = (fullInstance \ "schema").extractOpt[String].flatMap(x => SchemaKey.fromUri(x).right.toOption).getOrElse {
+        val schemaKey = (fullInstance \ "schema").extractOpt[String].flatMap(x => SchemaKey.fromUri(x).toOption).getOrElse {
           throw new MappingException("Does not contain schema key with valid Schema URI")
         }
         val data = fullInstance \ "data" match {

--- a/0-common/scala-core/src/test/scala/com/snowplowanalytics/iglu/core/SchemaKeySpec.scala
+++ b/0-common/scala-core/src/test/scala/com/snowplowanalytics/iglu/core/SchemaKeySpec.scala
@@ -83,7 +83,7 @@ class SchemaKeySpec extends Specification { def is = s2"""
       DescribedString("com.snowplowanalytics.snowplow", "mobile_context", "jsonschema", 1, 1, 1, "111")
     )
 
-    describedData.sortBy(SchemaKey.extract(_).right.getOrElse(throw new RuntimeException("Not possible")) ) must beEqualTo(Seq(
+    describedData.sortBy(SchemaKey.extract(_).getOrElse(throw new RuntimeException("Not possible")) ) must beEqualTo(Seq(
       DescribedString("com.snowplowanalytics.snowplow", "aobile_context", "jsonschema", 2, 1, 0, "210"),
       DescribedString("com.snowplowanalytics.snowplow", "mobile_context", "avro", 2, 1, 0, "210"),
       DescribedString("com.snowplowanalytics.snowplow", "mobile_context", "jsonschema", 1, 0, 0, "100"),


### PR DESCRIPTION
Update library versions to the latest.
Remove support for 2.11, because circe does not support 2.11 in the latest version.
Remove unused cats imports.